### PR TITLE
Feat: add new JSX transform support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,5 +33,7 @@ module.exports = {
     "no-underscore-dangle": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "react/jsx-props-no-spreading": "off",
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off",
   },
 }

--- a/packages/gatsby-theme/.storybook/main.js
+++ b/packages/gatsby-theme/.storybook/main.js
@@ -17,7 +17,7 @@ module.exports = {
     config.module.rules[0].use[0].loader = require.resolve("babel-loader")
     // use @babel/preset-react for JSX and env (instead of staged presets)
     config.module.rules[0].use[0].options.presets = [
-      require.resolve("@babel/preset-react"),
+      [require.resolve("@babel/preset-react"), { runtime: "automatic" }],
       require.resolve("@babel/preset-env"),
     ]
     config.module.rules[0].use[0].options.plugins = [

--- a/packages/gatsby-theme/.storybook/preview.js
+++ b/packages/gatsby-theme/.storybook/preview.js
@@ -1,4 +1,3 @@
-import React from "react"
 import { ThemeProvider } from "theme-ui"
 import { action } from "@storybook/addon-actions"
 

--- a/packages/gatsby-theme/src/components/Button/index.js
+++ b/packages/gatsby-theme/src/components/Button/index.js
@@ -1,8 +1,8 @@
-import React from "react"
+import { forwardRef } from "react"
 import PropTypes from "prop-types"
 import { Box, useThemeUI } from "theme-ui"
 
-const Button = React.forwardRef(({ to, variant, as, children, ...props }, ref) => {
+const Button = forwardRef(({ to, variant, as, children, ...props }, ref) => {
   const { theme } = useThemeUI()
   return (
     <Box

--- a/packages/gatsby-theme/src/components/Grid/Grid.js
+++ b/packages/gatsby-theme/src/components/Grid/Grid.js
@@ -1,4 +1,3 @@
-import React from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 

--- a/packages/gatsby-theme/src/components/Grid/GridColumn.js
+++ b/packages/gatsby-theme/src/components/Grid/GridColumn.js
@@ -1,4 +1,3 @@
-import React from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 

--- a/packages/gatsby-theme/src/components/Icon/index.js
+++ b/packages/gatsby-theme/src/components/Icon/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import { forwardRef } from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 import {
@@ -33,7 +33,7 @@ const Icons = {
   link: FaLink,
 }
 
-const Icon = React.forwardRef(({ icon, variant, ...props }, ref) => {
+const Icon = forwardRef(({ icon, variant, ...props }, ref) => {
   return (
     <Box
       ref={ref}

--- a/packages/gatsby-theme/src/components/Image/index.js
+++ b/packages/gatsby-theme/src/components/Image/index.js
@@ -1,10 +1,10 @@
-import React from "react"
+import { forwardRef } from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 import Img from "gatsby-image"
 import RichText from "../RichText"
 
-const Image = React.forwardRef(({ variant, caption, image, ...props }, ref) => {
+const Image = forwardRef(({ variant, caption, image, ...props }, ref) => {
   const isGatsbyImage = !image.src
   return (
     <Box as='figure' __css={{ m: 0 }} {...props}>

--- a/packages/gatsby-theme/src/components/InfiniteScroll/index.js
+++ b/packages/gatsby-theme/src/components/InfiniteScroll/index.js
@@ -1,4 +1,3 @@
-import React from "react"
 import PropTypes from "prop-types"
 import InfiniteScrollLib from "react-infinite-scroll-component"
 

--- a/packages/gatsby-theme/src/components/Link/index.js
+++ b/packages/gatsby-theme/src/components/Link/index.js
@@ -1,42 +1,40 @@
-import React from "react"
+import { forwardRef } from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 import GatsbyLink from "gatsby-link"
 
-const Link = React.forwardRef(
-  ({ to, children, variant, ariaLabel, ...props }, ref) => {
-    const internal = /^\/(?!\/)/.test(to)
-    const samePage = /^#/.test(to)
+const Link = forwardRef(({ to, children, variant, ariaLabel, ...props }, ref) => {
+  const internal = /^\/(?!\/)/.test(to)
+  const samePage = /^#/.test(to)
 
-    return internal ? (
-      <Box
-        __themeKey='styles'
-        ref={ref}
-        aria-label={ariaLabel}
-        variant={variant}
-        as={GatsbyLink}
-        to={to}
-        {...props}
-      >
-        {children}
-      </Box>
-    ) : (
-      <Box
-        __themeKey='styles'
-        ref={ref}
-        aria-label={ariaLabel}
-        variant={variant}
-        as='a'
-        href={to}
-        target={!samePage ? "_blank" : ""}
-        rel={!samePage ? "noopener noreferrer" : ""}
-        {...props}
-      >
-        {children}
-      </Box>
-    )
-  }
-)
+  return internal ? (
+    <Box
+      __themeKey='styles'
+      ref={ref}
+      aria-label={ariaLabel}
+      variant={variant}
+      as={GatsbyLink}
+      to={to}
+      {...props}
+    >
+      {children}
+    </Box>
+  ) : (
+    <Box
+      __themeKey='styles'
+      ref={ref}
+      aria-label={ariaLabel}
+      variant={variant}
+      as='a'
+      href={to}
+      target={!samePage ? "_blank" : ""}
+      rel={!samePage ? "noopener noreferrer" : ""}
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+})
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/gatsby-theme/src/components/Loading/index.js
+++ b/packages/gatsby-theme/src/components/Loading/index.js
@@ -1,4 +1,3 @@
-import React from "react"
 import { Box, Divider } from "theme-ui"
 import PropTypes from "prop-types"
 import ContentLoader from "react-content-loader"

--- a/packages/gatsby-theme/src/components/RichText/index.js
+++ b/packages/gatsby-theme/src/components/RichText/index.js
@@ -1,8 +1,8 @@
-import React from "react"
+import { forwardRef } from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 
-const RichText = React.forwardRef(({ as, text, children, ...props }, ref) => {
+const RichText = forwardRef(({ as, text, children, ...props }, ref) => {
   if (text || typeof children === "string") {
     return (
       <Box

--- a/packages/gatsby-theme/src/components/Section/index.js
+++ b/packages/gatsby-theme/src/components/Section/index.js
@@ -1,4 +1,3 @@
-import React from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 

--- a/packages/gatsby-theme/src/components/VideoEmbed/index.js
+++ b/packages/gatsby-theme/src/components/VideoEmbed/index.js
@@ -1,4 +1,3 @@
-import React from "react"
 import PropTypes from "prop-types"
 import { Box } from "theme-ui"
 import ReactPlayer from "react-player/lazy"


### PR DESCRIPTION
Added support for the new JSX transform as described in the following blog post: 

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

Adding the following parameter to the babel preset configuration enables the new feature: 

![image](https://user-images.githubusercontent.com/41605725/100761030-083ac380-33b8-11eb-9a88-23634b1434c6.png)

The following linting rules had to be turned off because of this:
```javascript
    "react/jsx-uses-react": "off",
    "react/react-in-jsx-scope": "off",
```
