### PR TITLE
Refactor: remove withA11y decorator in stories

### DIFF
--- a/packages/gatsby-theme/src/components/Grid/Grid.stories.mdx
+++ b/packages/gatsby-theme/src/components/Grid/Grid.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import { Box } from "theme-ui"
 import Grid from "."
 

--- a/packages/gatsby-theme/src/components/Icon/Icon.stories.mdx
+++ b/packages/gatsby-theme/src/components/Icon/Icon.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import Icon from "."
 
 <Meta title='components/Icon' component={Icon} />
@@ -15,7 +14,7 @@ Insert icons
 ### Github
 
 <Preview>
-  <Story name='Github' decorators={[withA11y]}>
+  <Story name='Github'>
     <Icon icon='github' />
   </Story>
 </Preview>
@@ -23,7 +22,7 @@ Insert icons
 ### Twitter
 
 <Preview>
-  <Story name='Twitter' decorators={[withA11y]}>
+  <Story name='Twitter'>
     <Icon icon='twitter' />
   </Story>
 </Preview>
@@ -31,7 +30,7 @@ Insert icons
 ### Linkedin
 
 <Preview>
-  <Story name='Linkedin' decorators={[withA11y]}>
+  <Story name='Linkedin'>
     <Icon icon='linkedin' />
   </Story>
 </Preview>
@@ -39,7 +38,7 @@ Insert icons
 ### Times
 
 <Preview>
-  <Story name='Times' decorators={[withA11y]}>
+  <Story name='Times'>
     <Icon icon='times' />
   </Story>
 </Preview>
@@ -47,7 +46,7 @@ Insert icons
 ### Bars
 
 <Preview>
-  <Story name='Bars' decorators={[withA11y]}>
+  <Story name='Bars'>
     <Icon icon='bars' variant='mobileMenu' />
   </Story>
 </Preview>

--- a/packages/gatsby-theme/src/components/Image/Image.stories.mdx
+++ b/packages/gatsby-theme/src/components/Image/Image.stories.mdx
@@ -1,8 +1,7 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { withA11y } from '@storybook/addon-a11y'
-import Image from '.'
+import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
+import Image from "."
 
-<Meta title="components/Image" component={Image} />
+<Meta title='components/Image' component={Image} />
 
 # Image
 
@@ -15,11 +14,11 @@ Use to insert image
 ### Default
 
 <Preview>
-  <Story name="Default" decorators={[withA11y]}>
+  <Story name='Default'>
     <Image
       image={{
-        src: 'https://placeimg.com/640/480/any',
-        alt: 'tech related stuff',
+        src: "https://placeimg.com/640/480/any",
+        alt: "tech related stuff",
       }}
     />
   </Story>
@@ -28,11 +27,11 @@ Use to insert image
 ### Avatar
 
 <Preview>
-  <Story name="Avatar" decorators={[withA11y]}>
+  <Story name='Avatar'>
     <Image
-      variant="avatar"
+      variant='avatar'
       image={{
-        src: 'https://placeimg.com/240/240/people',
+        src: "https://placeimg.com/240/240/people",
         alt: `someone's avatar`,
       }}
     />
@@ -42,11 +41,11 @@ Use to insert image
 ### With Caption
 
 <Preview>
-  <Story name="With Caption" decorators={[withA11y]}>
+  <Story name='With Caption'>
     <Image
       image={{
-        src: 'https://placeimg.com/640/480/any',
-        alt: 'tech related stuff',
+        src: "https://placeimg.com/640/480/any",
+        alt: "tech related stuff",
       }}
       caption="A caption with a <a href='/'>link</a>"
     />

--- a/packages/gatsby-theme/src/components/InfiniteScroll/InfiniteScroll.stories.mdx
+++ b/packages/gatsby-theme/src/components/InfiniteScroll/InfiniteScroll.stories.mdx
@@ -1,11 +1,10 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { withA11y } from '@storybook/addon-a11y'
-import { useState } from 'react'
-import { Box } from 'theme-ui'
-import Grid from '../Grid'
-import InfiniteScroll from '.'
+import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
+import { useState } from "react"
+import { Box } from "theme-ui"
+import Grid from "../Grid"
+import InfiniteScroll from "."
 
-<Meta title="components/InfiniteScroll" component={InfiniteScroll} />
+<Meta title='components/InfiniteScroll' component={InfiniteScroll} />
 
 # InfiniteScroll
 
@@ -18,16 +17,13 @@ Use to insert an InfiniteScroll
 ### XD
 
 <Preview>
-  <Story name="Infinite Scroll" decorators={[withA11y]}>
+  <Story name='Infinite Scroll'>
     {() => {
       const [hasMore, setHasMore] = useState(true)
       const fullContent = Array.from(Array(18), (v, i) => i)
       const [items, setItems] = useState(fullContent.slice(0, 6))
       const fetchNext = () => {
-        setItems([
-          ...items,
-          ...fullContent.slice(items.length, items.length + 4),
-        ])
+        setItems([...items, ...fullContent.slice(items.length, items.length + 4)])
         if (items.length === fullContent.length) {
           setHasMore(false)
         }
@@ -37,18 +33,18 @@ Use to insert an InfiniteScroll
           dataLength={items.length}
           nextHandler={() => fetchNext()}
           hasMore={hasMore}
-          scrollThreshold="200px"
+          scrollThreshold='200px'
         >
           <Grid columns={2}>
             {items.map((val) => (
               <Box
                 __css={{
-                  textAlign: 'center',
-                  py: 'xlarge',
-                  bg: '#ffe8a3',
-                  m: 'small',
-                  borderRadius: '10px',
-                  fontSize: '70px',
+                  textAlign: "center",
+                  py: "xlarge",
+                  bg: "#ffe8a3",
+                  m: "small",
+                  borderRadius: "10px",
+                  fontSize: "70px",
                 }}
               >
                 {val}

--- a/packages/gatsby-theme/src/components/Link/Link.stories.mdx
+++ b/packages/gatsby-theme/src/components/Link/Link.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import Link from "."
 
 <Meta title='components/Link' component={Link} />

--- a/packages/gatsby-theme/src/components/Loading/Loading.stories.mdx
+++ b/packages/gatsby-theme/src/components/Loading/Loading.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import Loading from "."
 import { Box } from "theme-ui"
 
@@ -16,7 +15,7 @@ Use this component to insert loading placeholder skeletons
 ### Contact
 
 <Preview>
-  <Story name='Contact' decorators={[withA11y]}>
+  <Story name='Contact'>
     <Box variant='wrapper' __themeKey='container'>
       <Loading type='contact' />
     </Box>
@@ -26,7 +25,7 @@ Use this component to insert loading placeholder skeletons
 ### Blog Listing
 
 <Preview>
-  <Story name='Blog Listing' decorators={[withA11y]}>
+  <Story name='Blog Listing'>
     <Box variant='wrapper' __themeKey='container'>
       <Loading type='blog_list' />
     </Box>

--- a/packages/gatsby-theme/src/components/RichText/RichText.stories.mdx
+++ b/packages/gatsby-theme/src/components/RichText/RichText.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import RichText from "."
 import { Box } from "theme-ui"
 
@@ -26,7 +25,7 @@ Use this component to insert rich text
 ### Body Text
 
 <Preview>
-  <Story name='Default' decorators={[withA11y]}>
+  <Story name='Default'>
     <RichText sx={{ fontSize: "1rem" }}>{data}</RichText>
   </Story>
 </Preview>
@@ -34,7 +33,7 @@ Use this component to insert rich text
 ### Single text child
 
 <Preview>
-  <Story name='Single text child' decorators={[withA11y]}>
+  <Story name='Single text child'>
     <RichText>{"<button>An HTML button</button>"}</RichText>
   </Story>
 </Preview>
@@ -42,7 +41,7 @@ Use this component to insert rich text
 ### Single node child
 
 <Preview>
-  <Story name='Single node child' decorators={[withA11y]}>
+  <Story name='Single node child'>
     <RichText>
       <Box>A theme-ui Box node</Box>
     </RichText>
@@ -52,7 +51,7 @@ Use this component to insert rich text
 ### Multiple node children
 
 <Preview>
-  <Story name='Multiple node children' decorators={[withA11y]}>
+  <Story name='Multiple node children'>
     <RichText>
       <Box>A theme-ui Box node</Box>
       <Box>Another theme-ui Box node</Box>

--- a/packages/gatsby-theme/src/components/Section/Section.stories.mdx
+++ b/packages/gatsby-theme/src/components/Section/Section.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
-import { withA11y } from "@storybook/addon-a11y"
 import Section from "."
 import Grid from "../Grid"
 
@@ -16,7 +15,7 @@ Use this component to add a background color to a section and a container.
 ### Default background
 
 <Preview>
-  <Story name='Default' decorators={[withA11y]}>
+  <Story name='Default'>
     <Section sx={{ p: 4 }}>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Quam magnam saepe
       ratione dolor voluptatem voluptatum numquam nemo recusandae quisquam aspernatur
@@ -28,7 +27,7 @@ Use this component to add a background color to a section and a container.
 ### Dark background
 
 <Preview>
-  <Story name='Dark background' decorators={[withA11y]}>
+  <Story name='Dark background'>
     <Section variant='dark' isFull>
       <Grid>
         <Grid.Column columns='6' sx={{ p: 4 }}>
@@ -45,7 +44,7 @@ Use this component to add a background color to a section and a container.
 ### Light Background
 
 <Preview>
-  <Story name='Light Background' decorators={[withA11y]}>
+  <Story name='Light Background'>
     <Section variant='light' isFull>
       <Grid>
         <Grid.Column columns='6' sx={{ p: 4 }}>


### PR DESCRIPTION
This is way of enabling the a11y addon is deprecated:
```javascript
import { withA11y } from "@storybook/addon-a11y"
```

We already enabled the addon globally in the Storybook configuration.