### PR TITLE
Fix: add background color declaration

### DIFF
--- a/packages/gatsby-theme/src/gatsby-plugin-theme-ui/index.js
+++ b/packages/gatsby-theme/src/gatsby-plugin-theme-ui/index.js
@@ -2,6 +2,7 @@ const bColors = {
   transparent: "transparent",
   black: "#000",
   white: "#fff",
+  background: "#fff",
   primary: "#0CBFC7",
   secondary: "#CA3E73",
   darkShade: "#37375B",


### PR DESCRIPTION
Theme UI uses some specific color properties for elements like the background color: https://theme-ui.com/theme-spec/#color-modes

![image](https://user-images.githubusercontent.com/41605725/100775543-088f8a80-33c9-11eb-9ed4-e98442904d1d.png)
