### PR TITLE
feat: add text component & text block

### DIFF
--- a/packages/gatsby-theme/.storybook/main.js
+++ b/packages/gatsby-theme/.storybook/main.js
@@ -1,10 +1,7 @@
 const path = require(`path`)
 
 module.exports = {
-  stories: [
-    "../src/components/**/*.stories.mdx",
-    "../src/components/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-  ],
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-a11y",

--- a/packages/gatsby-theme/src/blocks/TextBlock/TextBlock.stories.mdx
+++ b/packages/gatsby-theme/src/blocks/TextBlock/TextBlock.stories.mdx
@@ -1,0 +1,71 @@
+import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
+
+import TextBlock from "."
+import Section from "../../components/Section"
+
+export const data = {
+  title: "Some nice title",
+  text: `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+          et magnis dis parturient montes, nascetur ridiculus mus. Donec quam
+          felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
+          consequat massa quis enim. Donec pede justo, fringilla vel, aliquet
+          nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,
+          venenatis vitae, justo.`,
+}
+
+export const richTextData = {
+  title: "Some nice title",
+  text: `<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+          et magnis dis parturient montes, <em>nascetur ridiculus mus</em>. Donec quam
+          felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
+          consequat massa quis enim. Donec pede justo, fringilla vel, aliquet
+          nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,
+          venenatis vitae, justo.</p>
+          <p>Lorem ipsum <strong>dolor sit amet</strong>, consectetuer adipiscing elit. Aenean
+          commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus
+          et magnis dis parturient montes, nascetur ridiculus mus. Donec quam
+          felis, ultricies nec, <a href="https://www.google.com/">pellentesque eu</a>, pretium quis, sem. Nulla
+          consequat massa quis enim. Donec pede justo, fringilla vel, aliquet
+          nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,
+          venenatis vitae, justo.</p>`,
+}
+
+<Meta title='blocks/TextBlock' component={TextBlock} />
+
+# TextBlock
+
+## Props
+
+<Props of={TextBlock} />
+
+### Default TextBlock
+
+<Preview>
+  <Story name='Default'>
+    <Section>
+      <TextBlock {...data} />
+    </Section>
+  </Story>
+</Preview>
+
+### Different align
+
+<Preview>
+  <Story name='Different align'>
+    <Section>
+      <TextBlock {...data} align='center' />
+    </Section>
+  </Story>
+</Preview>
+
+### Rich Text
+
+<Preview>
+  <Story name='Rich Text'>
+    <Section>
+      <TextBlock {...richTextData} />
+    </Section>
+  </Story>
+</Preview>

--- a/packages/gatsby-theme/src/blocks/TextBlock/index.js
+++ b/packages/gatsby-theme/src/blocks/TextBlock/index.js
@@ -17,8 +17,8 @@ TextBlock.propTypes = {
 }
 
 TextBlock.defaultProps = {
-  title: "",
-  text: "",
+  title: undefined,
+  text: undefined,
   align: "left",
 }
 

--- a/packages/gatsby-theme/src/blocks/TextBlock/index.js
+++ b/packages/gatsby-theme/src/blocks/TextBlock/index.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types"
+import Text from "../../components/Text"
+
+const TextBlock = ({ title, text, align, ...props }) => {
+  return (
+    <Text align={align} {...props}>
+      {title && <Text.Title>{title}</Text.Title>}
+      {text && <Text.Body>{text}</Text.Body>}
+    </Text>
+  )
+}
+
+TextBlock.propTypes = {
+  title: PropTypes.string,
+  text: PropTypes.string,
+  align: PropTypes.string,
+}
+
+TextBlock.defaultProps = {
+  title: "",
+  text: "",
+  align: "left",
+}
+
+export default TextBlock

--- a/packages/gatsby-theme/src/components/Text/Text.js
+++ b/packages/gatsby-theme/src/components/Text/Text.js
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types"
+import { Box } from "theme-ui"
+
+const Text = ({ align, children, ...props }) => {
+  return (
+    <Box
+      __css={{ textAlign: align }}
+      variant='wrapper'
+      __themeKey='container'
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}
+
+Text.propTypes = {
+  children: PropTypes.node.isRequired,
+  align: PropTypes.string,
+}
+
+Text.defaultProps = {
+  align: "left",
+}
+
+export default Text

--- a/packages/gatsby-theme/src/components/Text/Text.stories.mdx
+++ b/packages/gatsby-theme/src/components/Text/Text.stories.mdx
@@ -1,0 +1,72 @@
+import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
+import Text from "."
+import { Box } from "theme-ui"
+import Link from "../Link"
+
+<Meta title='components/Text' component={Text} />
+
+# Text
+
+Use this component to wrap common text
+
+## Props
+
+<Props of={Text} />
+
+### Body Text
+
+<Preview>
+  <Story name='Default'>
+    <Text>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet consectetur
+      temporibus id! Impedit corporis, exercitationem modi sed tenetur molestias
+      nesciunt sunt aspernatur deleniti velit officiis, consectetur, praesentium
+      omnis commodi. Ducimus?
+    </Text>
+  </Story>
+</Preview>
+
+### Different Align
+
+<Preview>
+  <Story name='Different Align'>
+    <Text align='center'>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet consectetur
+      temporibus id! Impedit corporis, exercitationem modi sed tenetur molestias
+      nesciunt sunt aspernatur deleniti velit officiis, consectetur, praesentium
+      omnis commodi. Ducimus?
+    </Text>
+  </Story>
+</Preview>
+
+### Using React Components
+
+<Preview>
+  <Story name='Using React Components'>
+    <Text>
+      <p>
+        This is <strong>bolded</strong> text. This is a <Link to='/'>link</Link>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet consectetur temporibus
+        id! <Box as='span' __css={{ color: "red" }}>
+          Impedit corporis
+        </Box>, exercitationem modi sed tenetur molestias nesciunt sunt aspernatur deleniti
+        velit officiis, <Box
+          as='span'
+          __css={{
+            borderBottom: "2px solid red",
+            transition: "1s",
+            ":hover": {
+              borderBottom: "5px solid red",
+            },
+          }}
+        >
+          consectetur, praesentium omnis commodi
+        </Box>. Ducimus?{" "}
+      </p>
+      <ol>
+        <li>Lorem</li>
+        <li>Ipsum</li>
+      </ol>
+    </Text>
+  </Story>
+</Preview>

--- a/packages/gatsby-theme/src/components/Text/index.js
+++ b/packages/gatsby-theme/src/components/Text/index.js
@@ -1,0 +1,8 @@
+import Text from "./Text"
+import Heading from "../Heading"
+import RichText from "../RichText"
+
+Text.Title = Heading
+Text.Body = RichText
+
+export default Text


### PR DESCRIPTION
ticket: [GAT-39](https://app.clickup.com/t/2257946/GAT-39)

- added configuration on .storybook/main.js to enable block components to be rendered
![image](https://user-images.githubusercontent.com/28025112/100805476-52419a80-33f4-11eb-93bd-e13d1c49167f.png)

- add Text component and TextBlock block




