### PR TITLE
Feat: add Card component

### DIFF
--- a/packages/gatsby-theme/src/components/Card/Card.js
+++ b/packages/gatsby-theme/src/components/Card/Card.js
@@ -1,0 +1,39 @@
+import { forwardRef } from "react"
+import PropTypes from "prop-types"
+import { Box } from "theme-ui"
+import Link from "../Link"
+
+const Card = forwardRef(({ children, align, to, ...props }, ref) => {
+  return (
+    <Box
+      as={to ? Link : "div"}
+      to={to}
+      ref={ref}
+      __css={{
+        p: ["small", null, "medium"],
+        textAlign: align,
+        color: "inherit",
+        ":hover": {
+          textDecoration: "none",
+        },
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+})
+
+Card.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
+    .isRequired,
+  to: PropTypes.string,
+  align: PropTypes.string,
+}
+
+Card.defaultProps = {
+  align: "left",
+  to: "",
+}
+
+export default Card

--- a/packages/gatsby-theme/src/components/Card/Card.stories.mdx
+++ b/packages/gatsby-theme/src/components/Card/Card.stories.mdx
@@ -1,0 +1,99 @@
+import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks"
+import Card from "."
+import Link from "../Link"
+import Icon from "../Icon"
+
+<Meta title='components/Card' component={Card} />
+
+# Card
+
+A Card component.
+
+## Props
+
+<Props of={Card} />
+
+### Default
+
+<Preview>
+  <Story name='Default'>
+    <Card>
+      <Card.Intro>Something awesome</Card.Intro>
+      <Link to='/' variant='default'>
+        <Card.Image
+          image={{
+            src: "https://placeimg.com/1000/480/tech",
+            alt: "tech related stuff",
+          }}
+        />
+      </Link>
+      <Card.Heading>Let&#39;s code something now</Card.Heading>
+      <Card.Text>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa.
+      </Card.Text>
+      <Card.Button to='/'>Hire us now!</Card.Button>
+    </Card>
+  </Story>
+</Preview>
+
+### Centered
+
+<Preview>
+  <Story name='Centered'>
+    <Card align='center'>
+      <Card.Intro>Something awesome</Card.Intro>
+      <Link to='/' variant='default'>
+        <Card.Image
+          image={{
+            src: "https://placeimg.com/1000/480/tech",
+            alt: "tech related stuff",
+          }}
+        />
+      </Link>
+      <Card.Heading>Let&#39;s code something now</Card.Heading>
+      <Card.Text>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa.
+      </Card.Text>
+      <Card.Button to='/'>Hire us now!</Card.Button>
+    </Card>
+  </Story>
+</Preview>
+
+## Blog Teaser
+
+<Preview>
+  <Story name='Blog Teaser'>
+    <Card
+      sx={{
+        maxWidth: 400,
+        border: "2px solid grey",
+        m: "medium",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+      }}
+    >
+      <Link to='/' variant='default'>
+        <Card.Image
+          image={{
+            src: "https://placeimg.com/1000/480/tech",
+            alt: "tech related stuff",
+          }}
+        />
+      </Link>
+      <Card.Heading>Let&#39;s code something now</Card.Heading>
+      <Card.Text sx={{ fontSize: "tiny" }}>
+        <Icon icon='calendar' sx={{ pt: 2, mr: "xsmall" }} />
+        Julio 2, 2020
+      </Card.Text>
+      <Card.RichText
+        sx={{ flex: 1 }}
+        text={`<strong>Lorem ipsum dolor sit amet</strong>, consectetuer adipiscing elit. 
+        Aenean commodo ligula eget dolor. Aenean massa.`}
+      />
+      <Card.Button to='/'>Read more</Card.Button>
+    </Card>
+  </Story>
+</Preview>

--- a/packages/gatsby-theme/src/components/Card/CardButton.js
+++ b/packages/gatsby-theme/src/components/Card/CardButton.js
@@ -1,0 +1,21 @@
+import PropTypes from "prop-types"
+import Button from "../Button"
+import Link from "../Link"
+
+const CardButton = ({ children, variant, to, ...props }) => (
+  <Button as={Link} variant={variant} to={to} {...props}>
+    {children}
+  </Button>
+)
+
+CardButton.propTypes = {
+  children: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired,
+  variant: PropTypes.string,
+}
+
+CardButton.defaultProps = {
+  variant: "primary",
+}
+
+export default CardButton

--- a/packages/gatsby-theme/src/components/Card/CardHeading.js
+++ b/packages/gatsby-theme/src/components/Card/CardHeading.js
@@ -1,0 +1,14 @@
+import PropTypes from "prop-types"
+import Heading from "../Heading"
+
+const CardHeading = ({ children, ...props }) => (
+  <Heading as='h3' {...props}>
+    {children}
+  </Heading>
+)
+
+CardHeading.propTypes = {
+  children: PropTypes.string.isRequired,
+}
+
+export default CardHeading

--- a/packages/gatsby-theme/src/components/Card/CardImage.js
+++ b/packages/gatsby-theme/src/components/Card/CardImage.js
@@ -1,0 +1,23 @@
+import PropTypes from "prop-types"
+import Image from "../Image"
+
+const CardImage = ({ image, ...props }) => <Image image={image} {...props} />
+
+CardImage.propTypes = {
+  image: PropTypes.oneOfType([
+    PropTypes.shape({
+      src: PropTypes.string.isRequired,
+      alt: PropTypes.string.isRequired,
+    }),
+    PropTypes.shape({
+      fluid: PropTypes.shape({}).isRequired,
+      alt: PropTypes.string.isRequired,
+    }),
+    PropTypes.shape({
+      fixed: PropTypes.shape({}).isRequired,
+      alt: PropTypes.string.isRequired,
+    }),
+  ]).isRequired,
+}
+
+export default CardImage

--- a/packages/gatsby-theme/src/components/Card/CardIntro.js
+++ b/packages/gatsby-theme/src/components/Card/CardIntro.js
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types"
+import Heading from "../Heading"
+
+const CardIntro = ({ children, variant, ...props }) => (
+  <Heading variant={variant} {...props}>
+    {children}
+  </Heading>
+)
+
+CardIntro.propTypes = {
+  children: PropTypes.string.isRequired,
+  variant: PropTypes.string,
+}
+
+CardIntro.defaultProps = {
+  variant: "intro",
+}
+
+export default CardIntro

--- a/packages/gatsby-theme/src/components/Card/CardRichText.js
+++ b/packages/gatsby-theme/src/components/Card/CardRichText.js
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types"
+import RichText from "../RichText"
+
+const CardRichText = ({ text, children, sx }) => (
+  <RichText sx={{ mb: "xsmall", ...sx }} text={text}>
+    {children}
+  </RichText>
+)
+
+CardRichText.propTypes = {
+  children: PropTypes.string,
+  text: PropTypes.string,
+  sx: PropTypes.shape({}),
+}
+
+CardRichText.defaultProps = {
+  children: "",
+  text: "",
+  sx: null,
+}
+
+export default CardRichText

--- a/packages/gatsby-theme/src/components/Card/CardText.js
+++ b/packages/gatsby-theme/src/components/Card/CardText.js
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types"
+import RichText from "../RichText"
+
+const CardText = ({ children, sx }) => (
+  <RichText sx={{ mb: "xsmall", ...sx }}>{children}</RichText>
+)
+
+CardText.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  sx: PropTypes.shape({}),
+}
+
+CardText.defaultProps = {
+  sx: null,
+}
+
+export default CardText

--- a/packages/gatsby-theme/src/components/Card/index.js
+++ b/packages/gatsby-theme/src/components/Card/index.js
@@ -1,0 +1,16 @@
+import Card from "./Card"
+import CardButton from "./CardButton"
+import CardHeading from "./CardHeading"
+import CardImage from "./CardImage"
+import CardIntro from "./CardIntro"
+import CardText from "./CardText"
+import CardRichText from "./CardRichText"
+
+Card.Button = CardButton
+Card.Heading = CardHeading
+Card.Image = CardImage
+Card.Intro = CardIntro
+Card.Text = CardText
+Card.RichText = CardRichText
+
+export default Card


### PR DESCRIPTION
### Default
By default, the card uses 100% width of the parent.
![image](https://user-images.githubusercontent.com/41605725/100914722-0dbc0a80-3499-11eb-8772-31766242d91d.png)


### Blog Teaser
The Blog Teaser has a defined width
![image](https://user-images.githubusercontent.com/41605725/100914613-e9f8c480-3498-11eb-8cc8-06b5636d8fc5.png)



