### PR TITLE
Draft: Storybook Controls showcase [DO NOT MERGE]

### DIFF
--- a/packages/gatsby-theme/src/components/Card/Card.stories.mdx
+++ b/packages/gatsby-theme/src/components/Card/Card.stories.mdx
@@ -3,7 +3,114 @@ import Card from "."
 import Link from "../Link"
 import Icon from "../Icon"
 
-<Meta title='components/Card' component={Card} />
+export const argTypes = {
+  align: {
+    control: {
+      type: "select",
+      options: ["left", "center", "right"],
+    },
+    table: {
+      category: "Card",
+    },
+  },
+  to: {
+    table: {
+      category: "Card",
+    },
+  },
+  children: {
+    table: {
+      disable: true,
+    },
+  },
+  Intro: {
+    control: "text",
+    table: {
+      category: "Card Intro",
+    },
+  },
+  Heading: {
+    control: "text",
+    table: {
+      category: "Card Heading",
+    },
+  },
+  LinkTo: {
+    control: "text",
+    table: {
+      category: "Card Link",
+    },
+  },
+  LinkVariant: {
+    control: "text",
+    table: {
+      category: "Card Link",
+    },
+  },
+  ImageSrc: {
+    control: "text",
+    table: {
+      category: "Card Image",
+    },
+  },
+  ImageAlt: {
+    control: "text",
+    table: {
+      category: "Card Image",
+    },
+  },
+  Text: {
+    control: "text",
+    table: {
+      category: "Card Text",
+    },
+  },
+  ButtonTo: {
+    control: "text",
+    table: {
+      category: "Card Button",
+    },
+  },
+  ButtonText: {
+    control: "text",
+    table: {
+      category: "Card Button",
+    },
+  },
+}
+
+export const BTemplate = ({
+  Intro,
+  Heading,
+  LinkTo,
+  LinkVariant,
+  ImageSrc,
+  ImageAlt,
+  Text,
+  ButtonTo,
+  ButtonText,
+  align,
+  to,
+}) => {
+  return (
+    <Card align={align} to={to}>
+      <Card.Intro>{Intro}</Card.Intro>
+      <Link to={LinkTo} variant={LinkVariant}>
+        <Card.Image
+          image={{
+            src: ImageSrc,
+            alt: ImageAlt,
+          }}
+        />
+      </Link>
+      <Card.Heading>{Heading}</Card.Heading>
+      <Card.Text>{Text}</Card.Text>
+      <Card.Button to={ButtonTo}>{ButtonText}</Card.Button>
+    </Card>
+  )
+}
+
+<Meta title='components/Card' component={Card} argTypes={argTypes} />
 
 # Card
 
@@ -13,27 +120,98 @@ A Card component.
 
 <Props of={Card} />
 
-### Default
+### With inner component
 
 <Preview>
-  <Story name='Default'>
-    <Card>
-      <Card.Intro>Something awesome</Card.Intro>
-      <Link to='/' variant='default'>
-        <Card.Image
-          image={{
-            src: "https://placeimg.com/1000/480/tech",
-            alt: "tech related stuff",
-          }}
-        />
-      </Link>
-      <Card.Heading>Let&#39;s code something now</Card.Heading>
-      <Card.Text>
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
-        ligula eget dolor. Aenean massa.
-      </Card.Text>
-      <Card.Button to='/'>Hire us now!</Card.Button>
-    </Card>
+  <Story
+    name='With inner component'
+    args={{
+      Intro: "Something awesome",
+      LinkTo: "/",
+      LinkVariant: "default",
+      ImageSrc: "https://placeimg.com/1000/480/tech",
+      ImageAlt: "tech related stuff",
+      Heading: "Let's code something now",
+      Text: `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa.`,
+      ButtonTo: "/",
+      ButtonText: "Hire us now!",
+    }}
+  >
+    {({
+      Intro,
+      Heading,
+      LinkTo,
+      LinkVariant,
+      ImageSrc,
+      ImageAlt,
+      Text,
+      ButtonTo,
+      ButtonText,
+      align,
+      to,
+    }) => {
+      return (
+        <Card align={align} to={to}>
+          <Card.Intro>{Intro}</Card.Intro>
+          <Link to={LinkTo} variant={LinkVariant}>
+            <Card.Image
+              image={{
+                src: ImageSrc,
+                alt: ImageAlt,
+              }}
+            />
+          </Link>
+          <Card.Heading>{Heading}</Card.Heading>
+          <Card.Text>{Text}</Card.Text>
+          <Card.Button to={ButtonTo}>{ButtonText}</Card.Button>
+        </Card>
+      )
+    }}
+  </Story>
+</Preview>
+
+### With outer component
+
+<Preview>
+  <Story
+    name='With outer component'
+    args={{
+      Intro: "Something awesome",
+      LinkTo: "/",
+      LinkVariant: "default",
+      ImageSrc: "https://placeimg.com/1000/480/tech",
+      ImageAlt: "tech related stuff",
+      Heading: "Let's code something now",
+      Text: `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa.`,
+      ButtonTo: "/",
+      ButtonText: "Hire us now!",
+    }}
+  >
+    {(args) => <BTemplate {...args} />}
+  </Story>
+</Preview>
+
+### With bind
+
+<Preview>
+  <Story
+    name='With bind'
+    args={{
+      Intro: "Something awesome",
+      LinkTo: "/",
+      LinkVariant: "default",
+      ImageSrc: "https://placeimg.com/1000/480/tech",
+      ImageAlt: "tech related stuff",
+      Heading: "Let's code something now",
+      Text: `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+        ligula eget dolor. Aenean massa.`,
+      ButtonTo: "/",
+      ButtonText: "Hire us now!",
+    }}
+  >
+    {BTemplate.bind({})}
   </Story>
 </Preview>
 


### PR DESCRIPTION
Since this is going to be a reference project for the community, good documentation is key. Recently, I noticed that the `show code` feature from Storybook  sometimes did not display the code correctly when controls were enabled. After some reasearch, the cause is the way component is added to the Story. This draft contains a modified Story for the `Card` component, with three different approaches. These are the three different ways the `show code` feature renders the component.

![image](https://user-images.githubusercontent.com/41605725/101198867-b9946000-3629-11eb-96c1-84b94914c43c.png)

![image](https://user-images.githubusercontent.com/41605725/101199439-81415180-362a-11eb-98a7-599482892eea.png)

![image](https://user-images.githubusercontent.com/41605725/101198933-cfa22080-3629-11eb-871f-db7786cc1e60.png)

Please check the story under `packages/gatsby-theme/src/components/Card/Card.stories.mdx` to see the differences.

Additionally, this Story supports grouping of controls, which could be really helpful for compound components.

![image](https://user-images.githubusercontent.com/41605725/101199315-50f9b300-362a-11eb-8c94-598fa6a1790e.png)
